### PR TITLE
support running on ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ subject-no-allosome.list
 tmp/
 bin/
 nohup.out
+.DS_Store
+outfile.txt
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ bin/
 nohup.out
 .DS_Store
 outfile.txt
-
+inputs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,13 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get -y install default-jre-headless && \
     apt-get -y install wget && \
+    apt-get -y install tabix bcftools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /openb.io/
+RUN mkdir -p /openb.io/inputs
 
-RUN mkdir -p /Users/rob/Desktop/family
-
-VOLUME /Users/rob/Desktop/family
+VOLUME /openb.io/inputs
 
 COPY get-dependencies.sh /openb.io/
 
@@ -20,4 +19,4 @@ RUN cd /openb.io; ./get-dependencies.sh
 
 COPY run-pipeline.sh /openb.io/
 
-ENTRYPOINT [ "cd",  "/openb.io;", "./run-pipeline.sh", "/Users/rob/Desktop/family/subject-no-allosome.list", "/Users/rob/Desktop/family/longs.ped" ] 
+ENTRYPOINT cd /openb.io; ./run-pipeline.sh inputs/subjects.list inputs/family.ped

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+#FROM debian:sid
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install default-jre-headless && \
+    apt-get -y install wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /openb.io/
+
+RUN mkdir -p /Users/rob/Desktop/family
+
+VOLUME /Users/rob/Desktop/family
+
+COPY get-dependencies.sh /openb.io/
+
+RUN cd /openb.io; ./get-dependencies.sh
+
+COPY run-pipeline.sh /openb.io/
+
+ENTRYPOINT [ "cd",  "/openb.io;", "./run-pipeline.sh", "/Users/rob/Desktop/family/subject-no-allosome.list", "/Users/rob/Desktop/family/longs.ped" ] 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build . -t openbio-ibd-pipline:0.1

--- a/clean-up.sh
+++ b/clean-up.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-rm ./tmp/*
+rm ./inputs/*.gz
+rm ./inputs/*.tbi
+rm ./inputs/*.ibd
+rm ./inputs/*.hbd
+rm ./inputs/*.warnings
+rm ./inputs/*.log

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -4,7 +4,6 @@
 set -e
 
 mkdir bin 
-mkdir tmp
 
 cd bin 
 
@@ -25,6 +24,6 @@ wget http://faculty.washington.edu/browning/refined-ibd/refined-ibd.16May19.ad5.
 wget http://faculty.washington.edu/sguy/IBD_relatedness.tar
 tar -xf IBD_relatedness.tar
 
+# get combined human genetic map
 wget http://openb.io/2vcf/plink.GRCh37.map.gz
-gunzip plink.GRC37.map.gz
-
+gunzip plink.GRCh37.map.gz

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -8,6 +8,7 @@ mkdir tmp
 
 cd bin 
 
+# get and unpack 2vcf
 wget https://github.com/plantimals/2vcf/releases/download/v0.5/2vcf_0.5_Linux_amd64.tar.gz
 tar -zxvf 2vcf_0.5_Linux_amd64.tar.gz 2vcf
 rm 2vcf_0.5_Linux_amd64.tar.gz
@@ -20,4 +21,10 @@ wget https://faculty.washington.edu/browning/beagle/beagle.24Aug19.3e8.jar
 
 wget http://faculty.washington.edu/browning/refined-ibd/refined-ibd.16May19.ad5.jar
 
+# get and unpack relatedness_v2.py
+wget http://faculty.washington.edu/sguy/IBD_relatedness.tar
+tar -xf IBD_relatedness.tar
+
+wget http://openb.io/2vcf/plink.GRCh37.map.gz
+gunzip plink.GRC37.map.gz
 

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -8,9 +8,9 @@ mkdir tmp
 
 cd bin 
 
-wget https://github.com/plantimals/2vcf/releases/download/v0.4.1/2vcf_0.4.1_Darwin_amd64.tar.gz
-tar -zxvf 2vcf_0.4.1_Darwin_amd64.tar.gz 2vcf
-rm 2vcf_0.4.1_Darwin_amd64.tar.gz
+wget https://github.com/plantimals/2vcf/releases/download/v0.5/2vcf_0.5_Linux_amd64.tar.gz
+tar -zxvf 2vcf_0.5_Linux_amd64.tar.gz 2vcf
+rm 2vcf_0.5_Linux_amd64.tar.gz
 
 wget http://openb.io/2vcf/2vcf-v2.1.vcf.gz
 

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo docker run -t --rm -v /Users/rob/git/openb.io/ibd-pipeline/inputs:/openb.io/inputs openbio-ibd-pipline:0.1

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -18,26 +18,33 @@ INPUT_MD5=`md5sum ${INPUT_LIST} | awk '{print $1}'`
 #path to the 2vcf binary
 TO_VCF="${BIN_DIRECTORY}/2vcf"
 
-#path to 2vcf reference
+# path to 2vcf reference
 REFERENCE="${BIN_DIRECTORY}/2vcf-v2.1.vcf.gz"
 
-#path to beagle4 jar
+# path to beagle4 jar
 BEAGLE4_JAR="${BIN_DIRECTORY}/beagle.r1399.jar"
 
-#path to beagle5 jar
+# path to beagle5 jar
 BEAGLE5_JAR="${BIN_DIRECTORY}/beagle.24Aug19.3e8.jar"
 
-#path to refined IBD jar
+# path to refined IBD jar
 REFINED_IBD_JAR="${BIN_DIRECTORY}/refined-ibd.16May19.ad5.jar"
 
-#path to merged VCF after conversion of inputs
+# path to merged VCF after conversion of inputs
 MERGED_VCF="${WORKING_DIRECTORY}/${INPUT_MD5}-merged.vcf.gz"
 
-#path to phased VCF
+# path to phased VCF
 PHASED_VCF="${WORKING_DIRECTORY}/${INPUT_MD5}-merged-phased"
 
-#path to output VCF of IBD calling
-PHASED_IBD_OUT="${WORKING_DIRECTORY}/${INPUT_MD5}-merged-phased-ibd-called.vcf.gz"
+# path to output VCF of IBD calling
+PHASED_IBD_OUT="${WORKING_DIRECTORY}/${INPUT_MD5}-merged-phased-ibd-called"
+
+# human genetic map
+GENETIC_MAP="${WORKING_DIRECTORY}/plink.GRC37.map"
+
+CM_THRESHOLD="1"
+
+RELATEDNESS="${WORKING_DIRECTORY}/${INPUT_MD5}-relatedness.txt"
 
 
 function indexVCF () {
@@ -97,9 +104,16 @@ function refinedIBD () {
   eval ${CMD}
 }
 
-echo ${INPUT_MD5}
+function relatedness () {
+  CMD="cat ${PHASED_IBD_OUT}.ibd | python bin/IBD_relatedness/relatedness_v1.py ${GENETIC_MAP} ${CM_THRESHOLD} > ${RELATEDNESS}"
+  eval ${CMD}
+}
 
-# main pipeline
+#################
+# main pipeline #
+#################
+
+echo "inputs/family.ped MD5: ${INPUT_MD5}"
 
 # run stage 1 - convert input to VCF
 ingestion
@@ -113,3 +127,6 @@ phasingB4
 # run stage 3 - phasing with beagle 5.1 and refinedIBD
 #phasingB5
 #refinedIBD
+
+# run stage 4 - relatedness
+relatedness

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -13,7 +13,7 @@ WORKING_DIRECTORY=./tmp
 BIN_DIRECTORY=./bin
 
 #unique identifier for a pipeline run, signature of inputs, the MD5 hash of the input list file
-INPUT_MD5=`md5 -q ${INPUT_LIST}`
+INPUT_MD5=`md5sum ${INPUT_LIST}`
 
 #path to the 2vcf binary
 TO_VCF="${BIN_DIRECTORY}/2vcf"

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -7,10 +7,10 @@ INPUT_LIST=$1
 PEDIGREE=$2
 
 #path to intermediate and result files
-WORKING_DIRECTORY=./inputs
+WORKING_DIRECTORY=/openb.io/inputs
 
 #path to binaries
-BIN_DIRECTORY=./bin
+BIN_DIRECTORY=/openb.io/bin
 
 #unique identifier for a pipeline run, signature of inputs, the MD5 hash of the input list file
 INPUT_MD5=`md5sum ${INPUT_LIST} | awk '{print $1}'`
@@ -40,11 +40,13 @@ PHASED_VCF="${WORKING_DIRECTORY}/${INPUT_MD5}-merged-phased"
 PHASED_IBD_OUT="${WORKING_DIRECTORY}/${INPUT_MD5}-merged-phased-ibd-called"
 
 # human genetic map
-GENETIC_MAP="${WORKING_DIRECTORY}/plink.GRC37.map"
+GENETIC_MAP="${BIN_DIRECTORY}/plink.GRCh37.map"
 
 CM_THRESHOLD="1"
 
-RELATEDNESS="${WORKING_DIRECTORY}/${INPUT_MD5}-relatedness.txt"
+RELATEDNESS="${BIN_DIRECTORY}/IBD_relatedness/relatedness_v1.py"
+
+RELATEDNESS_OUTPUT="${WORKING_DIRECTORY}/${INPUT_MD5}-relatedness.txt"
 
 
 function indexVCF () {
@@ -90,22 +92,23 @@ function merge () {
 
 # Stage 3 - phasing
 function phasingB4 () {
-  CMD="java -Xmx10g -jar ${BEAGLE4_JAR} nthreads=6 gt=${MERGED_VCF} impute=false gprobs=false ped=${PEDIGREE} ibd=true ibdlod=4.0 out=${PHASED_VCF}"
+  local CMD="java -Xmx10g -jar ${BEAGLE4_JAR} nthreads=6 gt=${MERGED_VCF} impute=false gprobs=false ped=${PEDIGREE} ibd=true ibdlod=4.0 out=${PHASED_VCF}"
   eval ${CMD}
 }
 
 function phasingB5 () {
-  CMD="java -Xmx10g -jar ${BEAGLE5_JAR} nthreads=4 gt=${MERGED_VCF} impute=false out=${PHASED_VCF}"
+  local CMD="java -Xmx10g -jar ${BEAGLE5_JAR} nthreads=4 gt=${MERGED_VCF} impute=false out=${PHASED_VCF}"
   eval ${CMD}
 }
 
 function refinedIBD () {
-  CMD="java -Xmx10g -jar ${REFINED_IBD_JAR} nthreads=6 gt=${PHASED_VCF}.vcf.gz.vcf.gz.vcf.gz out=${PHASED_IBD_OUT}"
+  local CMD="java -Xmx10g -jar ${REFINED_IBD_JAR} nthreads=6 gt=${PHASED_VCF}.vcf.gz.vcf.gz.vcf.gz out=${PHASED_IBD_OUT}"
   eval ${CMD}
 }
 
 function relatedness () {
-  CMD="cat ${PHASED_IBD_OUT}.ibd | python bin/IBD_relatedness/relatedness_v1.py ${GENETIC_MAP} ${CM_THRESHOLD} > ${RELATEDNESS}"
+  local CMD="cat ${PHASED_VCF}.ibd | python ${RELATEDNESS} ${GENETIC_MAP} ${CM_THRESHOLD} > ${RELATEDNESS_OUTPUT}"
+  echo "CMD=${CMD}"
   eval ${CMD}
 }
 
@@ -129,4 +132,4 @@ phasingB4
 #refinedIBD
 
 # run stage 4 - relatedness
-relatedness
+#relatedness

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -7,13 +7,13 @@ INPUT_LIST=$1
 PEDIGREE=$2
 
 #path to intermediate and result files
-WORKING_DIRECTORY=./tmp
+WORKING_DIRECTORY=./inputs
 
 #path to binaries
 BIN_DIRECTORY=./bin
 
 #unique identifier for a pipeline run, signature of inputs, the MD5 hash of the input list file
-INPUT_MD5=`md5sum ${INPUT_LIST}`
+INPUT_MD5=`md5sum ${INPUT_LIST} | awk '{print $1}'`
 
 #path to the 2vcf binary
 TO_VCF="${BIN_DIRECTORY}/2vcf"
@@ -97,17 +97,19 @@ function refinedIBD () {
   eval ${CMD}
 }
 
+echo ${INPUT_MD5}
+
 # main pipeline
 
 # run stage 1 - convert input to VCF
-
 ingestion
 
 # run stage 2 - merge VCF
 merge
 
-# run stage 3 - phasing
+# run stage 3 - phasing with beagle 4.1
 phasingB4
-#phasingB5
 
+# run stage 3 - phasing with beagle 5.1 and refinedIBD
+#phasingB5
 #refinedIBD

--- a/setup-ubuntu.sh
+++ b/setup-ubuntu.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install default-jre-headless && \
+    apt-get -y install wget && \
+    apt-get -y install tabix bcftools && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+./get-dependencies.sh


### PR DESCRIPTION
In order to allow this workflow to work in cross platform environments without a lot of customization, we have chosen to support the Ubuntu 18.04 LTS build as our native computing environment. This commit adds a Dockerfile based on ubuntu:18.04. 

The base components have been modified to work in this environment as well. this includes a linux binary of `2vcf`, using `md5sum` instead of OSX's `md5`, etc. 

There are a series of setup scripts which are also used by the Dockerfile to stage all the executables and flat file dependencies.

When starting with a fresh ubuntu VM, to run the pipeline locally:
```
apt-get update && \
    DEBIAN_FRONTEND=noninteractive \
    apt-get -y install default-jre-headless && \
    apt-get -y install wget && \
    apt-get -y install tabix bcftools && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/*
```
The above will install java, wget, tabix, and bcftools, all dependencies of the workflow. 

Then create `/openb.io` off the root, copy `get-dependencies.sh` to the openb.io directory and execute it. this will download the various dependencies. Then create `/openb.io/inputs` and place the `subjects.list` and `family.ped` files in it. Then execute `run-pipeline.sh subjects.list family.ped` to kick things off.